### PR TITLE
To avoid error "User root not allowed because account is locked" 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@ FROM alpine:latest
 # ssh-keygen -A generates all necessary host keys (rsa, dsa, ecdsa, ed25519) at default location.
 RUN    apk update \
     && apk add openssh \
+    && apk add openssh-server-pam \
     && mkdir /root/.ssh \
     && chmod 0700 /root/.ssh \
     && ssh-keygen -A \
     && sed -i s/^#PasswordAuthentication\ yes/PasswordAuthentication\ no/ /etc/ssh/sshd_config
+    && sed -i s/^#UsePAM\ no/UsePAM\ yes/ /etc/ssh/sshd_config
 
 # This image expects AUTHORIZED_KEYS environment variable to contain your ssh public key.
 


### PR DESCRIPTION
added PAM module and enabled it in sshd config